### PR TITLE
Fix: passing lowercase `y` to confirm prompt

### DIFF
--- a/nbs/00_core.ipynb
+++ b/nbs/00_core.ipynb
@@ -128,7 +128,7 @@
     "            \n",
     "        shall = True\n",
     "        if confirm:\n",
-    "            shall = input(\"%s (Y/n) \" % confirm_msg) == \"Y\"\n",
+    "            shall = input(\"%s (y/N) \" % confirm_msg).lower() == \"y\"\n",
     "        if shall:\n",
     "            U.download(model_url, filename, verify=ssl_verify)\n",
     "        else:\n",


### PR DESCRIPTION
Passing lowercase `y` as input to confirm prompt for downloading wasn't recognized.
With this PR, the user can pass any letter either `Y` or `y`, the `.lower()` method will convert it to lowercase and compare.

In cmd applications, usually the capitalized letter is the default operation. As default operation when not passing any input for confirm prompt is `n`. Hence I have capitalized `N` and removed capitalization for `y` .