### PR TITLE
Update the Docker build to leverage uv and its auto-detection of torch backend

### DIFF
--- a/docker/Dockerfile-cpu
+++ b/docker/Dockerfile-cpu
@@ -6,4 +6,4 @@ RUN python3 -m pip install torch torchvision torchaudio \
 RUN python3 -m pip install llama-cpp-python streamlit
 COPY . .
 RUN python3 -m pip install .
-CMD python3
+CMD ["python3"]

--- a/docker/Dockerfile-cuda
+++ b/docker/Dockerfile-cuda
@@ -1,15 +1,15 @@
 # Copied from https://github.com/abetlen/llama-cpp-python/blob/22917989003c5e67623d54ab45affa1e0e475410/docker/cuda_simple/Dockerfile
-ARG CUDA_IMAGE
+ARG CUDA_IMAGE="12.6.3-devel-ubuntu22.04"
 FROM nvidia/cuda:${CUDA_IMAGE}
+COPY --from=ghcr.io/astral-sh/uv:latest /uv /uvx /bin/
 
 # We need to set the host to 0.0.0.0 to allow outside access
-ENV HOST 0.0.0.0
+ENV HOST=0.0.0.0
 
-RUN apt-get update && apt-get upgrade -y \
-    && apt-get install -y git build-essential \
-    python3 python3-pip gcc wget \
-    ocl-icd-opencl-dev opencl-headers clinfo \
-    libclblast-dev libopenblas-dev \
+SHELL ["/bin/bash", "-c"]
+RUN apt-get update && apt-get upgrade -y
+RUN apt-get install -y git build-essential python3 gcc wget \
+    ocl-icd-opencl-dev opencl-headers clinfo libclblast-dev libopenblas-dev \
     && mkdir -p /etc/OpenCL/vendors \
     && echo "libnvidia-opencl.so.1" > /etc/OpenCL/vendors/nvidia.icd
 
@@ -18,22 +18,25 @@ ENV CUDA_DOCKER_ARCH=all
 ENV LLAMA_CUBLAS=1
 
 # Install dependencies
-RUN python3 -m pip install --upgrade pip wheel setuptools
-ARG TORCH_INDEX_URL
-RUN python3 -m pip install torch torchvision torchaudio \
-  --index-url ${TORCH_INDEX_URL}
-RUN python3 -m pip install --upgrade pytest cmake scikit-build fastapi uvicorn \
+RUN uv venv --seed --python 3.10 /opt/venv
+# Use the virtual environment automatically
+ENV VIRTUAL_ENV=/opt/venv
+# Place entry points in the environment at the front of the path
+ENV PATH="/opt/venv/bin:$PATH"
+RUN uv pip install torch torchvision torchaudio --torch-backend=auto
+RUN uv pip install --upgrade pytest cmake scikit-build fastapi uvicorn \
   sse-starlette pydantic-settings starlette-context
 
 # Install llama-cpp-python (build with cuda)
-RUN CMAKE_ARGS="-DGGML_CUDA=on" FORCE_CMAKE=1 python3 -m pip install --upgrade --force-reinstall llama-cpp-python --no-cache-dir
+RUN CMAKE_ARGS="-DGGML_CUDA=on" FORCE_CMAKE=1 python -m pip install --upgrade \
+    --force-reinstall llama-cpp-python --no-cache-dir
 
 # Install Streamlit
-RUN python3 -m pip install streamlit
+RUN uv pip install streamlit
 
 # Copy the context in, and use it to install onprem from source
 COPY . .
-RUN python3 -m pip install .
+RUN uv pip install -e .
 
 # Default to launching into the REPL
-CMD python3
+CMD ["python3"]

--- a/docker/get_cuda_image_tag
+++ b/docker/get_cuda_image_tag
@@ -1,9 +1,22 @@
 #!/usr/bin/env python3
 from sys import argv, exit, stderr
-from typing import Dict, Tuple
+from typing import Tuple
 
 # Supported devel-ubuntu22.04 image CUDA versions
-HUB_IMAGE_VERSIONS = ["11.7.1", "11.8.0", "12.0.1", "12.1.1", "12.2.2", "12.3.0"]
+HUB_IMAGE_VERSIONS = [
+    "11.7.1",
+    "11.8.0",
+    "12.0.1",
+    "12.1.1",
+    "12.2.2",
+    "12.3.2",
+    "12.4.1",
+    "12.5.1",
+    "12.6.3",
+    "12.8.1",
+    "12.9.1",
+    "13.0.0"
+]
 
 
 def get_major_minor(version: str) -> Tuple[int, int]:
@@ -42,11 +55,14 @@ def main(cuda_version: str):
             selected_image_minor = image_minor
             selected_image_version = hub_version
     if selected_image_minor is None:
-        print("Something went wrong. I couldn't find a supported image version to use.\n"
-              "You likely need to update your NVIDIA Device driver.",
-              file=stderr)
+        print(
+            "Something went wrong. I couldn't find a supported image version to use.\n"
+            "You likely need to update your NVIDIA Device driver.",
+            file=stderr,
+        )
         exit(1)
     print(selected_image_version)
+
 
 if __name__ == "__main__":
     if len(argv) != 2:


### PR DESCRIPTION
These changes worked for me, as long as I was disconnected from our work VPN, so that corporate firewall issues didn't get in the way. They are incomplete in that I added all available v11, v12 & v13 CUDA images, but the build script might not work correctly with v13 drivers.