### PR TITLE
Update deprecated Streamlit use_container_width parameter

### DIFF
--- a/onprem/app/OnPrem.py
+++ b/onprem/app/OnPrem.py
@@ -157,23 +157,23 @@ def main():
     col1, col2, col3, col4, col5 = st.columns(5)
     
     with col1:
-        if st.button("💬 Use Prompts", use_container_width=True):
+        if st.button("💬 Use Prompts", width='stretch'):
             st.switch_page("pages/1_Prompts.py")
-    
+
     with col2:
-        if st.button("📄 Talk to Documents", use_container_width=True):
+        if st.button("📄 Talk to Documents", width='stretch'):
             st.switch_page("pages/2_Document_QA.py")
-    
+
     with col3:
-        if st.button("📊 Document Analysis", use_container_width=True):
+        if st.button("📊 Document Analysis", width='stretch'):
             st.switch_page("pages/3_Document_Analysis.py")
-    
+
     with col4:
-        if st.button("🔍 Search Documents", use_container_width=True):
+        if st.button("🔍 Search Documents", width='stretch'):
             st.switch_page("pages/4_Document_Search.py")
-    
+
     with col5:
-        if st.button("🔧 Workflow Builder", use_container_width=True):
+        if st.button("🔧 Workflow Builder", width='stretch'):
             st.switch_page("pages/5_Workflow_Builder.py")
     
     # Additional information

--- a/onprem/app/pages/1_Prompts.py
+++ b/onprem/app/pages/1_Prompts.py
@@ -217,7 +217,7 @@ def main():
         st.markdown("### Chat Options")
         
         # Add a primary-colored button to clear chat
-        if st.button("🗑️ New Chat", type="primary", use_container_width=True):
+        if st.button("🗑️ New Chat", type="primary", width='stretch'):
             st.session_state.messages = [
                 {"role": SYSTEM, "content": "Chat history cleared. How can I help you today?"}
             ]
@@ -233,7 +233,7 @@ def main():
         
         # Create buttons for example prompts
         for i, example in enumerate(example_prompts):
-            if st.button(f"💡 {example}", key=f"example_{i}", use_container_width=True):
+            if st.button(f"💡 {example}", key=f"example_{i}", width='stretch'):
                 # Store the example in a session variable to be processed on the next rerun
                 st.session_state.example_to_process = example
                 

--- a/onprem/app/pages/3_Document_Search.py
+++ b/onprem/app/pages/3_Document_Search.py
@@ -321,10 +321,10 @@ def main():
     button_cols = st.columns([1, 1, 4])  # First two columns for buttons, third for spacing
     with button_cols[0]:
         # Keep button label consistently as "Search"
-        search_button = st.button("Search", type="primary", use_container_width=True)
+        search_button = st.button("Search", type="primary", width='stretch')
     with button_cols[1]:
         # Place the reset button immediately to the right of the search button
-        reset_button = st.button("Reset", type="secondary", use_container_width=True)
+        reset_button = st.button("Reset", type="secondary", width='stretch')
     
     # Reset search state if reset button is clicked
     if reset_button:
@@ -774,14 +774,14 @@ def main():
                     # First page button
                     with pagination_cols[0]:
                         if st.session_state.current_page > 1:
-                            if st.button("❮❮ First", key="first_page", use_container_width=True):
+                            if st.button("❮❮ First", key="first_page", width='stretch'):
                                 st.session_state.current_page = 1
                                 st.rerun()
-                    
+
                     # Previous page button
                     with pagination_cols[1]:
                         if st.session_state.current_page > 1:
-                            if st.button("❮ Previous", key="prev_page", use_container_width=True):
+                            if st.button("❮ Previous", key="prev_page", width='stretch'):
                                 st.session_state.current_page -= 1
                                 st.rerun()
                     
@@ -803,14 +803,14 @@ def main():
                     # Next page button
                     with pagination_cols[3]:
                         if st.session_state.current_page < total_pages:
-                            if st.button("Next ❯", key="next_page", use_container_width=True):
+                            if st.button("Next ❯", key="next_page", width='stretch'):
                                 st.session_state.current_page += 1
                                 st.rerun()
-                    
+
                     # Last page button
                     with pagination_cols[4]:
                         if st.session_state.current_page < total_pages:
-                            if st.button("Last ❯❯", key="last_page", use_container_width=True):
+                            if st.button("Last ❯❯", key="last_page", width='stretch'):
                                 st.session_state.current_page = total_pages
                                 st.rerun()
                                 

--- a/onprem/app/pages/4_Document_Analysis.py
+++ b/onprem/app/pages/4_Document_Analysis.py
@@ -293,7 +293,7 @@ def main():
 
         # Display results preview
         st.subheader("Results Preview")
-        st.dataframe(results_df, use_container_width=True)
+        st.dataframe(results_df, width='stretch')
         
         # Add option to start a new analysis
         if st.button("Start New Analysis", key="new_analysis_button"):
@@ -388,9 +388,9 @@ def main():
     # Action buttons
     button_cols = st.columns([1, 1, 4])  # First two columns for buttons, third for spacing
     with button_cols[0]:
-        analyze_button = st.button("Analyze", type="primary", use_container_width=True)
+        analyze_button = st.button("Analyze", type="primary", width='stretch')
     with button_cols[1]:
-        reset_button = st.button("Reset", type="secondary", use_container_width=True)
+        reset_button = st.button("Reset", type="secondary", width='stretch')
     
     # Reset state if reset button is clicked - simplest approach is to set a flag and rerun
     if reset_button:

--- a/onprem/app/pages/5_Workflow_Builder.py
+++ b/onprem/app/pages/5_Workflow_Builder.py
@@ -977,7 +977,7 @@ def display_workflow_results(results):
         
         # Display complete results (following Document Analysis pattern)
         st.subheader("Results")
-        st.dataframe(results_df, use_container_width=True, height=400)
+        st.dataframe(results_df, width='stretch', height=400)
         
         # Create download button (following Document Analysis pattern)
         col1, col2 = st.columns([4, 1])


### PR DESCRIPTION
Was glancing at the repo and noticed an easy issue to tackle. Hope you are well, Arun!

Replace use_container_width=True with width='stretch' across all Streamlit components (buttons and dataframes) to comply with Streamlit's deprecation notice. The use_container_width parameter will be removed after 2025-12-31.
 
Changes made in:
- onprem/app/OnPrem.py (5 buttons)
- onprem/app/pages/1_Prompts.py (2 buttons)
- onprem/app/pages/3_Document_Search.py (6 buttons)
- onprem/app/pages/4_Document_Analysis.py (2 buttons, 1 dataframe)
- onprem/app/pages/5_Workflow_Builder.py (1 dataframe)

Fixes  #224 

🤖 Generated with [Claude Code](https://claude.com/claude-code)