### PR TITLE
docs: fix parameter typos

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -776,7 +776,7 @@ Most recent releases are shown at the top. Each release shows:
 
 ### changed
 - Added `k` and `score_threshold` arguments to `LLM.ask` (#122)
-- Added `n_proc` paramter to control the number of CPUs used 
+- Added `n_proc` parameter to control the number of CPUs used
   by `LLM.ingest` (ee09807)
 - Upgrade version of `chromadb` (#125)
 
@@ -1103,7 +1103,7 @@ Added `preproc_fn` to `Extractor.apply` (#74)
 - Uses [Zephyr-7B](https://huggingface.co/TheBloke/zephyr-7B-beta-GGUF) as default model in `webapp.yml`. (#52)
 
 ### changed
-- Added `stop` paramter to `LLM.prompt` (overrides `stop` paramter supplied to constructor) (#53)
+- Added `stop` parameter to `LLM.prompt` (overrides `stop` parameter supplied to constructor) (#53)
 
 ### fixed:
 - N/A

--- a/onprem/sk/tm.py
+++ b/onprem/sk/tm.py
@@ -666,7 +666,7 @@ class TopicModel:
 
          - n_neighbors: # of neighbors to use
          - metric: metric to use
-         - p: paramter to default Minkowsi metric
+         - p: parameter to default Minkowsi metric
         """
         from sklearn.neighbors import NearestNeighbors
 


### PR DESCRIPTION
## Summary
- fix `paramter` spelling in changelog entries and a docstring

## Validation
- git diff --check
- python3 -m py_compile onprem/sk/tm.py
- targeted typo assertion: `paramter` -> `parameter`

Confidence: 85/100 (docs/docstring typo)